### PR TITLE
document_hidden type for use with doctrine_mongodb

### DIFF
--- a/DependencyInjection/GliferyEntityHiddenTypeExtension.php
+++ b/DependencyInjection/GliferyEntityHiddenTypeExtension.php
@@ -23,6 +23,14 @@ class GliferyEntityHiddenTypeExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-        $loader->load('services.yml');
+
+        $bundles = $container->getParameter('kernel.bundles');
+
+        if (isset($bundles['DoctrineBundle'])) {
+            $loader->load('doctrine_orm.yml');
+        }
+        if (isset($bundles['DoctrineMongoDBBundle'])) {
+            $loader->load('doctrine_mongodb.yml');
+        }
     }
 }

--- a/Form/DataTransformer/ObjectToIdTransformer.php
+++ b/Form/DataTransformer/ObjectToIdTransformer.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
-class EntityToIdTransformer implements DataTransformerInterface
+class ObjectToIdTransformer implements DataTransformerInterface
 {
     /**
      * @var string
@@ -25,7 +25,7 @@ class EntityToIdTransformer implements DataTransformerInterface
     /**
      * @var EntityManager
      */
-    protected $em;
+    protected $om;
 
     /** @var EntityRepository */
     protected $repository;
@@ -35,12 +35,12 @@ class EntityToIdTransformer implements DataTransformerInterface
      * @param string $class
      * @param string $property
      */
-    public function __construct(ManagerRegistry $registry, $em, $class, $property)
+    public function __construct(ManagerRegistry $registry, $om, $class, $property)
     {
         $this->class = $class;
         $this->property = $property;
-        $this->em = $this->getEntityManager($registry, $em);
-        $this->repository = $this->getEntityRepository($this->em, $this->class);
+        $this->em = $this->getObjectManager($registry, $om);
+        $this->repository = $this->getObjectRepository($this->em, $this->class);
     }
 
     /**
@@ -55,7 +55,7 @@ class EntityToIdTransformer implements DataTransformerInterface
 
         $className = $this->repository->getClassName();
         if (!$entity instanceof $className) {
-            throw new TransformationFailedException(sprintf('Entity must be instance of %s, instance of %s has given.', $className, get_class($entity)));
+            throw new TransformationFailedException(sprintf('Object must be instance of %s, instance of %s has given.', $className, get_class($entity)));
         }
 
         $methodName = 'get'.ucfirst($this->property);
@@ -87,32 +87,32 @@ class EntityToIdTransformer implements DataTransformerInterface
 
     /**
      * @param ManagerRegistry $registry
-     * @param ObjectManager|string $emName
+     * @param ObjectManager|string $omName
      * @return ObjectManager
      */
-    private function getEntityManager(ManagerRegistry $registry, $emName) {
-        if ($emName instanceof ObjectManager) {
-            return $emName;
+    private function getObjectManager(ManagerRegistry $registry, $omName) {
+        if ($omName instanceof ObjectManager) {
+            return $omName;
         }
 
-        $emName = (string)$emName;
-        if ($em = $registry->getManager($emName)) {
-            return $em;
+        $omName = (string)$omName;
+        if ($om = $registry->getManager($omName)) {
+            return $om;
         }
 
-        throw new InvalidConfigurationException(sprintf('Doctrine ORM Manager named "%s" does not exist.', $emName));
+        throw new InvalidConfigurationException(sprintf('Doctrine Manager named "%s" does not exist.', $omName));
     }
 
     /**
-     * @param ObjectManager $em
+     * @param ObjectManager $om
      * @param string $class
-     * @return EntityRepository
+     * @return ObjectRepository
      */
-    private function getEntityRepository(ObjectManager $em, $class) {
-        if ($repo = $em->getRepository($class)) {
+    private function getObjectRepository(ObjectManager $om, $class) {
+        if ($repo = $om->getRepository($class)) {
             return $repo;
         }
 
-        throw new InvalidConfigurationException(sprintf('Entity Repository for class "%s" does not exist.', $class));
+        throw new InvalidConfigurationException(sprintf('Repository for class "%s" does not exist.', $class));
     }
 }

--- a/Form/Type/DocumentHiddenType.php
+++ b/Form/Type/DocumentHiddenType.php
@@ -8,7 +8,7 @@ use Glifery\EntityHiddenTypeBundle\Form\DataTransformer\ObjectToIdTransformer;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-class EntityHiddenType extends AbstractType
+class DocumentHiddenType extends AbstractType
 {
     /**
      * @var ManagerRegistry
@@ -29,7 +29,7 @@ class EntityHiddenType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $transformer = new ObjectToIdTransformer($this->registry, $options['em'], $options['class'], $options['property']);
+        $transformer = new ObjectToIdTransformer($this->registry, $options['dm'], $options['class'], $options['property']);
         $builder->addModelTransformer($transformer);
     }
 
@@ -42,14 +42,14 @@ class EntityHiddenType extends AbstractType
             ->setRequired(array('class'))
             ->setDefaults(array(
                     'data_class' => null,
-                    'invalid_message' => 'The entity does not exist.',
+                    'invalid_message' => 'The document does not exist.',
                     'property' => 'id',
-                    'em' => 'default'
+                    'dm' => 'default'
                 ))
             ->setAllowedTypes(array(
                     'invalid_message' => array('null', 'string'),
                     'property' => array('null', 'string'),
-                    'em' => array('null', 'string', 'Doctrine\Common\Persistence\ObjectManager'),
+                    'dm' => array('null', 'string', 'Doctrine\Common\Persistence\ObjectManager'),
                 ))
         ;
     }
@@ -61,6 +61,6 @@ class EntityHiddenType extends AbstractType
 
     public function getName()
     {
-        return 'entity_hidden';
+        return 'document_hidden';
     }
 }

--- a/README.md
+++ b/README.md
@@ -41,10 +41,17 @@ You can use the `entity_hidden` type in your forms just like this:
         'class' => 'YourBundle:Entity' // That's all !
     ));
 ```
+You can also use the `document_hidden` type:```php
+<?php
+    // ...
+    $builder->add('document', 'document_hidden', array(
+        'class' => 'YourBundle:Document' // That's all !
+    ));
+```
 There is only one required option "class". You must specify entity class in Symfony format that you want to be used in your form.
 
 ### Advanced usage:
-You can use the `entity_hidden` type in your forms this way:
+You can use the `entity_hidden` or 'document_hidden' type in your forms this way:
 ```php
 <?php
     // ...

--- a/Resources/config/doctrine_mongodb.yml
+++ b/Resources/config/doctrine_mongodb.yml
@@ -1,0 +1,9 @@
+parameters:
+    glifery.entity_hidden_type.document_form_type.class: Glifery\EntityHiddenTypeBundle\Form\Type\DocumentHiddenType
+
+services:
+    glifery.entity_hidden_type.document_form_type:
+        class: %glifery.entity_hidden_type.document_form_type.class%
+        arguments: ["@doctrine_mongodb"]
+        tags:
+        - { name: form.type, alias: document_hidden }

--- a/Resources/config/doctrine_orm.yml
+++ b/Resources/config/doctrine_orm.yml
@@ -1,0 +1,9 @@
+parameters:
+    glifery.entity_hidden_type.entity_form_type.class: Glifery\EntityHiddenTypeBundle\Form\Type\EntityHiddenType
+
+services:
+    glifery.entity_hidden_type.entity_form_type:
+        class: %glifery.entity_hidden_type.entity_form_type.class%
+        arguments: ["@doctrine"]
+        tags:
+        - { name: form.type, alias: entity_hidden }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,9 +1,0 @@
-parameters:
-    glifery.entity_hidden_type.form_type.class: Glifery\EntityHiddenTypeBundle\Form\Type\EntityHiddenType
-
-services:
-    glifery.entity_hidden_type.form_type:
-        class: %glifery.entity_hidden_type.form_type.class%
-        arguments: ["@doctrine"]
-        tags:
-        - { name: form.type, alias: entity_hidden }


### PR DESCRIPTION
The document_hidden type is only activated in case the DoctrineMongoDBBundle is active.
